### PR TITLE
ci: add cargo checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: DeterminateSystems/nix-installer-action@v10
     - uses: DeterminateSystems/magic-nix-cache-action@v4
-    - run: nix shell nixpkgs#cargo-toml-lint nixpkgs#findutils --command git ls-files | grep Cargo.toml$ | xargs --verbose -n 1 cargo-toml-lint
+    - run: nix shell nixpkgs#cargo-toml-lint nixpkgs#findutils --command git ls-files | grep Cargo.toml$ | xargs --verbose -n 1 $(which cargo-toml-lint)
 
   # Test the apps.
   apps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,5 +82,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: DeterminateSystems/nix-installer-action@v10
-      - uses: DeterminateSystems/magic-nix-cache-action@v4
+      # - uses: DeterminateSystems/magic-nix-cache-action@v4
       - run: ${{ matrix.command }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,6 @@ jobs:
 
   cargo:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: "write" # added for magic-nix-cache-action
-      contents: "read"  # added for magic-nix-cache-action
     strategy:
       fail-fast: false
       matrix:
@@ -57,12 +54,11 @@ jobs:
           - command: fmt --all -- --check
     steps:
     - uses: actions/checkout@v3
-    - uses: DeterminateSystems/nix-installer-action@v10
-    - uses: DeterminateSystems/magic-nix-cache-action@v4
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy, rustfmt
     - uses: Swatinem/rust-cache@v2
-    - env:
-        TMPDIR: ${{ runner.temp }}
-      run: nix develop .#essential-rust-app-dev --command cargo ${{ matrix.command }}
+    - run: cargo ${{ matrix.command }}
 
   # TODO: Update/fork this tool to provide a simpler, cargo-plugin-style CLI
   # so that it can be merged in the command table above

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,9 @@ jobs:
               ls
               which rustc
               which cargo
-              nix develop .#essential-rust-app-dev --command ls && which rustc && which cargo
+              rustc --version
+              cargo --version
+              nix develop .#essential-rust-app-dev --command ls && which rustc && which cargo && rustc --version && cargo --version
               nix develop .#essential-rust-app-dev --command cargo check --locked --all
               nix develop .#essential-rust-app-dev --command cargo clippy --locked --all -- -D warnings
               nix develop .#essential-rust-app-dev --command cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,10 @@ jobs:
           - command: nix run .#test-app-counter -- 44001
           - command: |
               nix run .#compile-all-contracts
+              ls
+              which rustc
+              which cargo
+              nix develop .#essential-rust-app-dev --command ls && which rustc && which cargo
               nix develop .#essential-rust-app-dev --command cargo check --locked --all
               nix develop .#essential-rust-app-dev --command cargo clippy --locked --all -- -D warnings
               nix develop .#essential-rust-app-dev --command cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,50 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@v4
       - run: nix ${{ matrix.command }}
 
+  cargo:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: "write" # added for magic-nix-cache-action
+      contents: "read"  # added for magic-nix-cache-action
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - command: check --locked --all
+          - command: clippy --locked --all -- -D warnings
+          - command: fmt --all -- --check
+          - command: test --locked --all
+          - command: test --no-default-features --locked --all
+          - command: test --all-features --locked --all -- --nocapture
+    env:
+        CARGO_NET_GIT_FETCH_WITH_CLI: 'true'
+    steps:
+    - uses: actions/checkout@v3
+    - uses: webfactory/ssh-agent@v0.9.0
+      with:
+        ssh-private-key: |
+            ${{ secrets.SSH_PRIVATE_KEY }}
+            ${{ secrets.SSH_PRIVATE_KEY_SELF }}
+    - uses: DeterminateSystems/nix-installer-action@v10
+    - uses: DeterminateSystems/magic-nix-cache-action@v4
+    - uses: Swatinem/rust-cache@v2
+    - env:
+        TMPDIR: ${{ runner.temp }}
+      run: nix develop --command cargo ${{ matrix.command }}
+
+  # TODO: Update/fork this tool to provide a simpler, cargo-plugin-style CLI
+  # so that it can be merged in the command table above
+  cargo-toml-lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo install --version "0.1.1" cargo-toml-lint
+    - run: git ls-files | grep Cargo.toml$ | xargs --verbose -n 1 cargo-toml-lint
+
   # Test the apps.
   apps:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,23 +43,6 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@v4
       - run: nix ${{ matrix.command }}
 
-  cargo:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - command: check --locked --all
-          - command: clippy --locked --all -- -D warnings
-          - command: fmt --all -- --check
-    steps:
-    - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        components: clippy, rustfmt
-    - uses: Swatinem/rust-cache@v2
-    - run: cargo ${{ matrix.command }}
-
   # TODO: Update/fork this tool to provide a simpler, cargo-plugin-style CLI
   # so that it can be merged in the command table above
   cargo-toml-lint:
@@ -83,6 +66,9 @@ jobs:
           - command: nix run .#test-app-counter -- 44001
           - command: |
               nix run .#compile-all-contracts
+              nix develop .#essential-rust-app-dev --command cargo check --locked --all
+              nix develop .#essential-rust-app-dev --command cargo clippy --locked --all -- -D warnings
+              nix develop .#essential-rust-app-dev --command cargo fmt --all -- --check
               nix develop .#essential-rust-app-dev --command cargo test
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,6 @@ jobs:
           - command: check --locked --all
           - command: clippy --locked --all -- -D warnings
           - command: fmt --all -- --check
-          - command: test --locked --all
-          - command: test --no-default-features --locked --all
-          - command: test --all-features --locked --all -- --nocapture
     steps:
     - uses: actions/checkout@v3
     - uses: DeterminateSystems/nix-installer-action@v10
@@ -65,7 +62,7 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - env:
         TMPDIR: ${{ runner.temp }}
-      run: nix develop --command cargo ${{ matrix.command }}
+      run: nix develop .#essential-rust-app-dev --command cargo ${{ matrix.command }}
 
   # TODO: Update/fork this tool to provide a simpler, cargo-plugin-style CLI
   # so that it can be merged in the command table above

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,15 +58,8 @@ jobs:
           - command: test --locked --all
           - command: test --no-default-features --locked --all
           - command: test --all-features --locked --all -- --nocapture
-    env:
-        CARGO_NET_GIT_FETCH_WITH_CLI: 'true'
     steps:
     - uses: actions/checkout@v3
-    - uses: webfactory/ssh-agent@v0.9.0
-      with:
-        ssh-private-key: |
-            ${{ secrets.SSH_PRIVATE_KEY }}
-            ${{ secrets.SSH_PRIVATE_KEY_SELF }}
     - uses: DeterminateSystems/nix-installer-action@v10
     - uses: DeterminateSystems/magic-nix-cache-action@v4
     - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: DeterminateSystems/nix-installer-action@v10
     - uses: DeterminateSystems/magic-nix-cache-action@v4
-    - run: nix shell nixpkgs#cargo-toml-lint --command git ls-files | grep Cargo.toml$ | xargs --verbose -n 1 cargo-toml-lint
+    - run: nix shell nixpkgs#cargo-toml-lint nixpkgs#findutils --command git ls-files | grep Cargo.toml$ | xargs --verbose -n 1 cargo-toml-lint
 
   # Test the apps.
   apps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: DeterminateSystems/nix-installer-action@v10
-    - uses: DeterminateSystems/magic-nix-cache-action@v4
+    # - uses: DeterminateSystems/magic-nix-cache-action@v4
     - run: nix fmt -- --check ./
 
   # Check the devShell works on macOS and Linux.
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: DeterminateSystems/nix-installer-action@v10
-      - uses: DeterminateSystems/magic-nix-cache-action@v4
+      # - uses: DeterminateSystems/magic-nix-cache-action@v4
       - run: nix ${{ matrix.command }}
 
   # # TODO: Update/fork this tool to provide a simpler, cargo-plugin-style CLI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: DeterminateSystems/nix-installer-action@v10
-    # - uses: DeterminateSystems/magic-nix-cache-action@v4
+    - uses: DeterminateSystems/magic-nix-cache-action@v4
     - run: nix fmt -- --check ./
 
   # Check the devShell works on macOS and Linux.
@@ -40,20 +40,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: DeterminateSystems/nix-installer-action@v10
-      # - uses: DeterminateSystems/magic-nix-cache-action@v4
+      - uses: DeterminateSystems/magic-nix-cache-action@v4
       - run: nix ${{ matrix.command }}
 
-  # # TODO: Update/fork this tool to provide a simpler, cargo-plugin-style CLI
-  # # so that it can be merged in the command table above
-  # cargo-toml-lint:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - uses: actions-rs/toolchain@v1
-  #     with:
-  #       toolchain: stable
-  #   - run: cargo install --version "0.1.1" cargo-toml-lint
-  #   - run: git ls-files | grep Cargo.toml$ | xargs --verbose -n 1 cargo-toml-lint
+  # TODO: Update/fork this tool to provide a simpler, cargo-plugin-style CLI
+  # so that it can be merged in the command table above
+  cargo-toml-lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: DeterminateSystems/nix-installer-action@v10
+    - uses: DeterminateSystems/magic-nix-cache-action@v4
+    - run: nix shell nixpkgs#cargo-toml-lint --command git ls-files | grep Cargo.toml$ | xargs --verbose -n 1 cargo-toml-lint
 
   # Test the apps.
   apps:
@@ -65,15 +63,7 @@ jobs:
           - command: nix run .#test-app-counter -- 44001
           - command: |
               nix run .#compile-all-contracts
-              ls
-              which rustc
-              which cargo
-              rustc --version
-              cargo --version
-              nix develop .#essential-rust-app-dev --command ls && which rustc && which cargo && rustc --version && cargo --version
-              nix develop .#essential-rust-app-dev --command cargo check --locked --all
-              nix develop .#essential-rust-app-dev --command cargo clippy --locked --all -- -D warnings
-              nix develop .#essential-rust-app-dev --command cargo fmt --all -- --check
+              nix develop .#essential-rust-app-dev --command cargo check --locked --all && cargo clippy --locked --all -- -D warnings && cargo fmt --all -- --check
               nix develop .#essential-rust-app-dev --command cargo test
     runs-on: ubuntu-latest
     permissions:
@@ -82,5 +72,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: DeterminateSystems/nix-installer-action@v10
-      # - uses: DeterminateSystems/magic-nix-cache-action@v4
+      - uses: DeterminateSystems/magic-nix-cache-action@v4
       - run: ${{ matrix.command }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,17 +43,17 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@v4
       - run: nix ${{ matrix.command }}
 
-  # TODO: Update/fork this tool to provide a simpler, cargo-plugin-style CLI
-  # so that it can be merged in the command table above
-  cargo-toml-lint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-    - run: cargo install --version "0.1.1" cargo-toml-lint
-    - run: git ls-files | grep Cargo.toml$ | xargs --verbose -n 1 cargo-toml-lint
+  # # TODO: Update/fork this tool to provide a simpler, cargo-plugin-style CLI
+  # # so that it can be merged in the command table above
+  # cargo-toml-lint:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - uses: actions-rs/toolchain@v1
+  #     with:
+  #       toolchain: stable
+  #   - run: cargo install --version "0.1.1" cargo-toml-lint
+  #   - run: git ls-files | grep Cargo.toml$ | xargs --verbose -n 1 cargo-toml-lint
 
   # Test the apps.
   apps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
-    - uses: Swatinem/rust-cache@v2
     - run: cargo install --version "0.1.1" cargo-toml-lint
     - run: git ls-files | grep Cargo.toml$ | xargs --verbose -n 1 cargo-toml-lint
 

--- a/apps/nft/front_end/Cargo.toml
+++ b/apps/nft/front_end/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-essential-app-utils = { workspace = true }
 clap = { workspace = true }
+essential-app-utils = { workspace = true }
 essential-hash = { workspace = true }
 essential-rest-client = { workspace = true }
 essential-sign.workspace = true

--- a/apps/token/app/Cargo.toml
+++ b/apps/token/app/Cargo.toml
@@ -10,8 +10,8 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-essential-app-utils = { workspace = true }
 clap = { workspace = true }
+essential-app-utils = { workspace = true }
 essential-hash = { workspace = true }
 essential-rest-client = { workspace = true }
 essential-server-types = { workspace = true }

--- a/apps/utils/Cargo.toml
+++ b/apps/utils/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+essential-debugger = { workspace = true, optional = true }
 essential-hash = { workspace = true }
 essential-rest-client = { workspace = true, optional = true }
 essential-server-types = { workspace = true }
@@ -21,8 +22,6 @@ hex = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 toml.workspace = true
-
-essential-debugger = { workspace = true, optional = true }
 
 [features]
 test-utils = ["dep:essential-debugger", "dep:essential-rest-client"]

--- a/crates/essential-dry-run/Cargo.toml
+++ b/crates/essential-dry-run/Cargo.toml
@@ -15,6 +15,6 @@ essential-read = { workspace = true }
 essential-rest-client = { workspace = true }
 essential-server-types = { workspace = true }
 essential-types = { workspace = true }
-serde_json = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
+serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/flake.lock
+++ b/flake.lock
@@ -87,11 +87,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720418205,
-        "narHash": "sha256-cPJoFPXU44GlhWg4pUk9oUPqurPlCFZ11ZQPk21GTPU=",
+        "lastModified": 1720768451,
+        "narHash": "sha256-EYekUHJE2gxeo2pM/zM9Wlqw1Uw2XTJXOSAO79ksc4Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "655a58a72a6601292512670343087c2d75d859c1",
+        "rev": "7e7c39ea35c5cdd002cd4588b03a3fb9ece6fad9",
         "type": "github"
       },
       "original": {

--- a/shells/dev.nix
+++ b/shells/dev.nix
@@ -11,6 +11,8 @@
 , stdenv
 , libiconv
 , openssl
+, rustc
+, cargo
 }:
 mkShell {
   buildInputs = [
@@ -23,6 +25,8 @@ mkShell {
     rustfmt
     openssl
     openssl.dev
+    rustc
+    cargo
   ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.SystemConfiguration
   ];

--- a/shells/essential-rust-app-dev.nix
+++ b/shells/essential-rust-app-dev.nix
@@ -7,6 +7,8 @@
 , rqlite
 , rust-analyzer
 , rustfmt
+, rustc
+, cargo
 , lib
 , stdenv
 , libiconv
@@ -23,6 +25,8 @@ mkShell {
     rustfmt
     openssl
     openssl.dev
+    rustc
+    cargo
   ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.SystemConfiguration
   ];

--- a/shells/shell.nix
+++ b/shells/shell.nix
@@ -16,6 +16,8 @@
 , libiconv
 , openssl
 , mdbook
+, rustc
+, cargo
 }:
 mkShell {
   buildInputs = [
@@ -33,6 +35,8 @@ mkShell {
     openssl
     openssl.dev
     mdbook
+    rustc
+    cargo
   ] ++ lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.SystemConfiguration
   ];


### PR DESCRIPTION
Regarding the TODO comment (that is copied from `essential-server`) about `cargo-toml-lint`:
I suggest we add a check to make sure that the spaces between brackets are unified, for example to:
favor `reqwest = { workspace = true, features = [ "json" ] }`
or `reqwest = { workspace = true, features = ["json"] }`
over `reqwest = { workspace = true, features = ["json"]}`
Any thoughts?

The `pint` repo is also using this tool, so CCing @mohammadfawaz for the question above. 

Closes #25 
