### PR TITLE
feat: invert matches in `essential-rest-client`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "essential-rest-client"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,5 +44,5 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 uuid = { version = "1.11.0", features = ["v4"] }
 
-essential-rest-client = { path = "crates/essential-rest-client", version = "0.4.0" }
-essential-app-utils = { path = "apps/utils", version = "0.5.0" }
+essential-rest-client = { path = "crates/essential-rest-client", version = "0.5.0" }
+essential-app-utils = { path = "apps/utils", version = "0.5.0 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,4 +45,4 @@ tracing-subscriber = "0.3.18"
 uuid = { version = "1.11.0", features = ["v4"] }
 
 essential-rest-client = { path = "crates/essential-rest-client", version = "0.5.0" }
-essential-app-utils = { path = "apps/utils", version = "0.5.0 }
+essential-app-utils = { path = "apps/utils", version = "0.5.0" }

--- a/crates/essential-rest-client/Cargo.toml
+++ b/crates/essential-rest-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "essential-rest-client"
 description = "Client for interacting with the Essential Server"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/crates/essential-rest-client/README.md
+++ b/crates/essential-rest-client/README.md
@@ -18,36 +18,22 @@ This is a Rust library and CLI tool that allows you to easily make rest requests
 
 #### Essential REST Client
 ```
-Usage: essential-rest-client <COMMAND>
+Usage: essential-rest-client <ADDRESS> <COMMAND>
 
 Commands:
-  node     Commands for calling node functions
-  builder  Commands for calling builder functions
-```
-
-#### Commands for Essential Node
-```
-Usage: essential-rest-client node <ADDRESS> <COMMAND>
-
-Commands:
-  list-blocks  List blocks in the given block number range
-  query-state  Query the state of a contract
+  list-blocks                   List blocks in the given block number range
+  query-state                   Query the state of a contract
+  deploy-contract               Deploy a contract
+  submit-solution               Submit a solution
+  latest-solution-failures      Get the latest failures for solution
+  help                          Print this message or the help of the given subcommand(s)
 
 Arguments:
-  <ADDRESS>  The endpoint of node to bind to
-```
+  <ADDRESS>
 
-#### Commands for Essential Builder
-```
-Usage: essential-rest-client builder <ADDRESS> <COMMAND>
-
-Commands:
-  deploy-contract           Deploy a contract
-  submit-solution           Submit a solution
-  latest-solution-failures  Get the latest failures for solution
-
-Arguments:
-  <ADDRESS>  The endpoint of builder to bind to
+Options:
+  -h, --help     Print help
+  -V, --version  Print version
 ```
 
 ## Essential REST Client

--- a/crates/essential-rest-client/README.md
+++ b/crates/essential-rest-client/README.md
@@ -18,18 +18,15 @@ This is a Rust library and CLI tool that allows you to easily make rest requests
 
 #### Essential REST Client
 ```
-Usage: essential-rest-client <ADDRESS> <COMMAND>
+Usage: essential-rest-client <COMMAND>
 
 Commands:
-  list-blocks                   List blocks in the given block number range
-  query-state                   Query the state of a contract
-  deploy-contract               Deploy a contract
-  submit-solution               Submit a solution
-  latest-solution-failures      Get the latest failures for solution
-  help                          Print this message or the help of the given subcommand(s)
-
-Arguments:
-  <ADDRESS>
+  list-blocks                     List blocks in the given block number range
+  query-state                     Query the state of a contract
+  deploy-contract                 Deploy a contract
+  submit-solution                 Submit a solution
+  latest-solution-failures        Get the latest failures for solution
+  help                            Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help     Print help

--- a/crates/essential-rest-client/README.md
+++ b/crates/essential-rest-client/README.md
@@ -1,6 +1,5 @@
 # essential-rest-client
 
-Version: 0.2.0
 [![Crates.io][crates-badge]][crates-url]
 [![Documentation][docs-badge]][docs-url]
 [![license][apache-badge]][apache-url]
@@ -17,30 +16,38 @@ Version: 0.2.0
 
 This is a Rust library and CLI tool that allows you to easily make rest requests to `essential-node` and `essential-builder`.
 
+#### Essential REST Client
 ```
-Essential REST Client
-
-Usage: essential-rest-client [NODE_ADDRESS] [BUILDER_ADDRESS] <COMMAND>
+Usage: essential-rest-client <COMMAND>
 
 Commands:
-  Node Commands:
-      get-contract                 Get a contract
-      get-predicate                Get a predicate
-      list-blocks                  List blocks in the given range
-      list-contracts               List contracts in the given block range
-      query-state                  Query state at contract address and key
-  Builder Commands:
-      submit-solution              Submit a solution
-      latest-solution-failures     Get the latest failures for a solution
-  help                             Print this message or the help of the given subcommand(s)
+  node     Commands for calling node functions
+  builder  Commands for calling builder functions
+```
+
+#### Commands for Essential Node
+```
+Usage: essential-rest-client node <ADDRESS> <COMMAND>
+
+Commands:
+  list-blocks  List blocks in the given block number range
+  query-state  Query the state of a contract
 
 Arguments:
-  [NODE_ADDRESS]  Optional node address to bind to
-  [BUILDER_ADDRESS]  Optional builder address to bind to
+  <ADDRESS>  The endpoint of node to bind to
+```
 
-Options:
-  -h, --help     Print help
-  -V, --version  Print version
+#### Commands for Essential Builder
+```
+Usage: essential-rest-client builder <ADDRESS> <COMMAND>
+
+Commands:
+  deploy-contract           Deploy a contract
+  submit-solution           Submit a solution
+  latest-solution-failures  Get the latest failures for solution
+
+Arguments:
+  <ADDRESS>  The endpoint of builder to bind to
 ```
 
 ## Essential REST Client
@@ -53,4 +60,4 @@ Block and state related endpoints.
 
 ### Essential Builder
 
-Solution submission related endpoints.
+Contract deployment and solution submission related endpoints.

--- a/crates/essential-rest-client/src/main.rs
+++ b/crates/essential-rest-client/src/main.rs
@@ -33,7 +33,6 @@ struct NodeCommand {
 #[derive(Parser, Debug)]
 struct BuilderCommand {
     /// The endpoint of builder to bind to.
-    #[arg(long)]
     address: String,
     #[command(subcommand)]
     command: BuilderCommands,

--- a/docs/code/counter-cargo.toml
+++ b/docs/code/counter-cargo.toml
@@ -8,7 +8,7 @@ anyhow = "1.0.91"
 clap = { version = "4.5.20", features = ["derive"] }
 essential-app-utils = "0.5.0"
 essential-hash = "0.4.0"
-essential-rest-client = "0.4.0"
+essential-rest-client = "0.5.0"
 essential-types = "0.3.0"
 tokio = { version = "1.41.0", features = ["full"] }
 

--- a/docs/code/deploy.sh
+++ b/docs/code/deploy.sh
@@ -17,5 +17,5 @@ cd ../
 
 # Deploy the contract
 # ANCHOR: deploy
-essential-rest-client --node-address "https://bigbangblock.builders" --builder-address "https://bigbangblock.builders" deploy-contract "contract/out/debug/counter.json"
+essential-rest-client builder "https://bigbangblock.builders" deploy-contract "contract/out/debug/counter.json"
 # ANCHOR_END: deploy

--- a/docs/code/deploy.sh
+++ b/docs/code/deploy.sh
@@ -17,5 +17,5 @@ cd ../
 
 # Deploy the contract
 # ANCHOR: deploy
-essential-rest-client deploy-contract "contract/out/debug/counter.json" "https://bigbangblock.builders" 
+essential-rest-client deploy-contract "https://bigbangblock.builders" "contract/out/debug/counter.json"
 # ANCHOR_END: deploy

--- a/docs/code/deploy.sh
+++ b/docs/code/deploy.sh
@@ -17,5 +17,5 @@ cd ../
 
 # Deploy the contract
 # ANCHOR: deploy
-essential-rest-client builder "https://bigbangblock.builders" deploy-contract "contract/out/debug/counter.json"
+essential-rest-client deploy-contract "contract/out/debug/counter.json" "https://bigbangblock.builders" 
 # ANCHOR_END: deploy

--- a/docs/getting-started/src/getting-started/architecture.md
+++ b/docs/getting-started/src/getting-started/architecture.md
@@ -1,7 +1,10 @@
 # Essential Architecture
+
 ---
+
 > **Note:**  
 > While efforts are made to maintain the Builder / Node state, schema changes may require wiping the database, resulting in a reset of stored data.
+
 ---
 
 ### Builder
@@ -18,24 +21,16 @@ The **Essential Integration** includes the **Essential REST Client**, which prov
 
 #### Essential REST Client Usage
 
-```bash
-essential-rest-client <COMMAND>
+``` bash
+Usage: essential-rest-client <ADDRESS_OF_NODE_OR_BUILDER> <COMMAND>
 
 Commands:
-  node <NODE_ADDRESS> <NODE_COMMAND>                Commands for calling node functions
-  builder <BUILDER_ADDRESS> <BUILDER_COMMAND>       Commands for calling builder functions
+  list-blocks                   List blocks in the given block number range
+  query-state                   Query the state of a contract
+  deploy-contract               Deploy a contract
+  submit-solution               Submit a solution
+  latest-solution-failures      Get the latest failures for solution
 ```
-
-#### Commands:
-
-- **Node Commands**:
-    - `list-blocks`: List blocks in the given block number range.
-    - `query-state`: Query the state of a contract.
-  
-- **Builder Commands**:
-    - `deploy-contract`: Deploy a contract.
-    - `submit-solution`: Submit a solution.
-    - `latest-solution-failures`: Get the latest failures for solution.
 
 This client simplifies interactions with the blockchain, offering key functionality for querying state and managing solutions.
 

--- a/docs/getting-started/src/getting-started/architecture.md
+++ b/docs/getting-started/src/getting-started/architecture.md
@@ -19,26 +19,23 @@ The **Essential Integration** includes the **Essential REST Client**, which prov
 #### Essential REST Client Usage
 
 ```bash
-essential-rest-client [NODE_ADDRESS] [BUILDER_ADDRESS] <COMMAND>
+essential-rest-client <COMMAND>
+
+Commands:
+  node <NODE_ADDRESS> <NODE_COMMAND>                Commands for calling node functions
+  builder <BUILDER_ADDRESS> <BUILDER_COMMAND>       Commands for calling builder functions
 ```
 
 #### Commands:
 
 - **Node Commands**:
-    - `get-contract`: Retrieve a contract.
-    - `get-predicate`: Fetch a predicate.
-    - `list-blocks`: List blocks within a range.
-    - `list-contracts`: List contracts in a block range.
-    - `query-state`: Query the state at a contract address and key.
+    - `list-blocks`: List blocks in the given block number range.
+    - `query-state`: Query the state of a contract.
   
 - **Builder Commands**:
-    - `submit-solution`: Submit a solution for validation.
-    - `latest-solution-failures`: Get the latest solution failures.
-
-#### Arguments:
-
-- `[NODE_ADDRESS]`: Optional Node address.
-- `[BUILDER_ADDRESS]`: Optional Builder address.
+    - `deploy-contract`: Deploy a contract.
+    - `submit-solution`: Submit a solution.
+    - `latest-solution-failures`: Get the latest failures for solution.
 
 This client simplifies interactions with the blockchain, offering key functionality for querying state and managing solutions.
 

--- a/docs/getting-started/src/getting-started/architecture.md
+++ b/docs/getting-started/src/getting-started/architecture.md
@@ -22,14 +22,14 @@ The **Essential Integration** includes the **Essential REST Client**, which prov
 #### Essential REST Client Usage
 
 ``` bash
-Usage: essential-rest-client <ADDRESS_OF_NODE_OR_BUILDER> <COMMAND>
+Usage: essential-rest-client <COMMAND>
 
 Commands:
-  list-blocks                   List blocks in the given block number range
-  query-state                   Query the state of a contract
-  deploy-contract               Deploy a contract
-  submit-solution               Submit a solution
-  latest-solution-failures      Get the latest failures for solution
+  list-blocks                     List blocks in the given block number range
+  query-state                     Query the state of a contract
+  deploy-contract                 Deploy a contract
+  submit-solution                 Submit a solution
+  latest-solution-failures        Get the latest failures for solution
 ```
 
 This client simplifies interactions with the blockchain, offering key functionality for querying state and managing solutions.

--- a/docs/getting-started/src/getting-started/counter/app/new.md
+++ b/docs/getting-started/src/getting-started/counter/app/new.md
@@ -52,16 +52,16 @@ After adding the test, your project structure should look like this:
 ```
 counter/
 ├── contract/
-│   ├── pint.toml                        
-│   ├── contract.pnt                         
+│   ├── pint.toml
+│   ├── contract.pnt
 │   └── src/
-│       └── contract.pnt                             
+│       └── contract.pnt
 └── counter-app/
-    ├── Cargo.toml                             
+    ├── Cargo.toml
     ├── tests/
-    │   └── counter.rs                   
+    │   └── counter.rs
     └── src/
-        └── lib.rs    
+        └── lib.rs
 ```
 
 At this point, your Rust project is set up with all the necessary dependencies, and a basic test has been added to your front-end application.


### PR DESCRIPTION
In the case of attempting to deploy a contract without passing a `--builder-address`, no feedback is given to the user of the CLI.

This PR: 
- Adds more context about which commands require a node / builder address specified. Since, for each command, either the node client or the builder client is used, this approach is way cleaner.
- Turns `print!`s to `println!`s, since the output looks convoluted otherwise.
- Updated docs that mention the usage of this tool.
- Bumps the version of `essential-rest-client`.

Closes #88 
