### PR TITLE
feat: Expose `essential-node`, `essential-builder` and `pint` packages from integration flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -84,10 +84,13 @@
       };
 
       packages = perSystemPkgs (pkgs: {
+        essential-builder = pkgs.essential-builder;
+        essential-node = pkgs.essential-node;
         essential-rest-client = pkgs.essential-rest-client;
         essential = pkgs.essential;
         book = pkgs.book;
         cargo-readme = pkgs.cargo-readme;
+        pint = pkgs.pint;
         pint-proj = pkgs.pint-proj;
         compile-all-contracts = pkgs.compile-all-contracts;
         default = inputs.self.packages.${pkgs.system}.essential;


### PR DESCRIPTION
This has the benefit of ensuring that users can grab individual tools from integration, while ensuring they're compatible with the rest of the tools at their currently pinned versions.