### PR TITLE
feat: Make `pint deploy` package-aware. For pint packages, build the package before deploying it.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2178,7 +2178,7 @@ checksum = "535996c1050511cbbd5b3e504084f02ba39123c611a72756a919b127dfacb3e6"
 dependencies = [
  "essential-types 0.5.0",
  "pint-abi-gen",
- "pint-abi-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pint-abi-types",
  "serde_json",
  "thiserror",
 ]
@@ -2191,20 +2191,13 @@ checksum = "407124c61c1b46bf1e910c681cb30ecb3052d1b6be72abe968b94fa52e35135e"
 dependencies = [
  "essential-hash 0.7.0",
  "essential-types 0.5.0",
- "pint-abi-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pint-abi-types",
  "pint-abi-visit",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
  "syn",
-]
-
-[[package]]
-name = "pint-abi-types"
-version = "0.4.0"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -2224,12 +2217,14 @@ checksum = "e5b6ab14a9532c3ec9a06cad94febd0e8f2d387804f922ffcc4ba5bc51f91122"
 dependencies = [
  "essential-types 0.5.0",
  "petgraph",
- "pint-abi-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pint-abi-types",
 ]
 
 [[package]]
 name = "pint-cli"
 version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9225e57148d13e0bba7a201df7f46fcbe3b6153f39aa2af454adfc3a4293eaf"
 dependencies = [
  "anyhow",
  "clap",
@@ -2256,6 +2251,8 @@ dependencies = [
 [[package]]
 name = "pint-manifest"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "032538c7dc7a70b3c7d8a7e0bbc84c33cfbc819c035afadfd7a0e7591876ba66"
 dependencies = [
  "serde",
  "serde_ignored",
@@ -2266,12 +2263,14 @@ dependencies = [
 [[package]]
 name = "pint-pkg"
 version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd45856b5a1d39414ec77063f87f3c3e48216f10f76351db1d1d328f8facdfc"
 dependencies = [
  "clap",
  "essential-hash 0.7.0",
  "essential-types 0.5.0",
  "petgraph",
- "pint-abi-types 0.4.0",
+ "pint-abi-types",
  "pint-manifest",
  "pintc",
  "serde",
@@ -2282,6 +2281,8 @@ dependencies = [
 [[package]]
 name = "pint-solve"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4e3825a2c3ec748324a9554f9376c3b94759ae0a11f323042f7ed6d2ffa163"
 dependencies = [
  "expect-test",
  "fxhash",
@@ -2306,6 +2307,8 @@ dependencies = [
 [[package]]
 name = "pintc"
 version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b379b85a5677dd31b1509a5f27129526e7c0d24ee058ee5d4948a7d5992b8bb"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -2321,7 +2324,7 @@ dependencies = [
  "lalrpop-util",
  "logos",
  "petgraph",
- "pint-abi-types 0.4.0",
+ "pint-abi-types",
  "pint-solve",
  "regex",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,10 +94,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
+name = "ariadne"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44055e597c674aef7cb903b2b9f6e4cba1277ed0d2d61dae7cd52d7ffa81f8e2"
+dependencies = [
+ "unicode-width",
+ "yansi",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
 
 [[package]]
 name = "async-trait"
@@ -212,6 +231,27 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitcoin-io"
@@ -454,6 +494,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +580,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +602,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +622,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dissimilar"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f8e79d1fbf76bdfbde321e902714bf6c49df88a7dda6fc682fc2979226962d"
 
 [[package]]
 name = "ed25519"
@@ -597,6 +670,15 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "ena"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1121,6 +1203,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "expect-test"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0be0a561335815e06dab7c62e50353134c796e7a6155402a64bcff66b6a5e0"
+dependencies = [
+ "dissimilar",
+ "once_cell",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1276,6 +1368,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
 dependencies = [
  "thread_local",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1682,6 +1783,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,6 +1813,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -1759,6 +1909,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "logos"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6b6e02facda28ca5fb8dbe4b152496ba3b1bd5a4b40bb2b1b2d8ad74e0f39b"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32eb6b5f26efacd015b000bfc562186472cd9b34bdba3f6b264e2a052676d10"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5d0c5463c911ef55624739fc353238b4e310f0144be1f875dc42fec6bfd5ec"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,6 +1996,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1955,6 +2144,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,7 +2178,7 @@ checksum = "535996c1050511cbbd5b3e504084f02ba39123c611a72756a919b127dfacb3e6"
 dependencies = [
  "essential-types 0.5.0",
  "pint-abi-gen",
- "pint-abi-types",
+ "pint-abi-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json",
  "thiserror",
 ]
@@ -1987,13 +2191,20 @@ checksum = "407124c61c1b46bf1e910c681cb30ecb3052d1b6be72abe968b94fa52e35135e"
 dependencies = [
  "essential-hash 0.7.0",
  "essential-types 0.5.0",
- "pint-abi-types",
+ "pint-abi-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pint-abi-visit",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
  "syn",
+]
+
+[[package]]
+name = "pint-abi-types"
+version = "0.4.0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2013,7 +2224,18 @@ checksum = "e5b6ab14a9532c3ec9a06cad94febd0e8f2d387804f922ffcc4ba5bc51f91122"
 dependencies = [
  "essential-types 0.5.0",
  "petgraph",
- "pint-abi-types",
+ "pint-abi-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pint-cli"
+version = "0.11.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "pint-pkg",
+ "serde_json",
+ "walkdir",
 ]
 
 [[package]]
@@ -2022,10 +2244,51 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "essential-hash 0.7.0",
  "essential-rest-client",
  "essential-types 0.5.0",
+ "pint-cli",
+ "pint-pkg",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "pint-manifest"
+version = "0.3.0"
+dependencies = [
+ "serde",
+ "serde_ignored",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
+name = "pint-pkg"
+version = "0.11.0"
+dependencies = [
+ "clap",
+ "essential-hash 0.7.0",
+ "essential-types 0.5.0",
+ "petgraph",
+ "pint-abi-types 0.4.0",
+ "pint-manifest",
+ "pintc",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "pint-solve"
+version = "0.1.0"
+dependencies = [
+ "expect-test",
+ "fxhash",
+ "lalrpop",
+ "lalrpop-util",
+ "thiserror",
+ "yansi",
 ]
 
 [[package]]
@@ -2038,6 +2301,35 @@ dependencies = [
  "essential-types 0.5.0",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "pintc"
+version = "0.11.0"
+dependencies = [
+ "anyhow",
+ "ariadne",
+ "clap",
+ "essential-constraint-asm 0.6.0",
+ "essential-hash 0.7.0",
+ "essential-state-asm 0.6.0",
+ "essential-types 0.5.0",
+ "expect-test",
+ "fxhash",
+ "itertools 0.13.0",
+ "lalrpop",
+ "lalrpop-util",
+ "logos",
+ "petgraph",
+ "pint-abi-types 0.4.0",
+ "pint-solve",
+ "regex",
+ "serde",
+ "serde_json",
+ "similar-asserts",
+ "slotmap",
+ "thiserror",
+ "yansi",
 ]
 
 [[package]]
@@ -2077,6 +2369,12 @@ checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
@@ -2392,6 +2690,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,6 +2798,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e319a36d1b52126a0d608f24e93b2d81297091818cd70625fcf50a15d84ddf"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2600,12 +2916,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+
+[[package]]
+name = "similar-asserts"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe85670573cd6f0fa97940f26e7e6601213c3b0555246c24234131f88c5709e"
+dependencies = [
+ "console",
+ "similar",
+]
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "slotmap"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -2648,6 +2995,19 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "string_cache"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
 
 [[package]]
 name = "strsim"
@@ -2733,6 +3093,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2760,6 +3131,15 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -3030,6 +3410,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3096,6 +3482,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -3217,6 +3613,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -3422,6 +3827,12 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ essential-signer = "0.4.0"
 essential-types = "0.5.0"
 essential-wallet = "0.5.0"
 pint-abi = "0.9.0"
+pint-cli = { path = "../pint/pint-cli" }
+pint-pkg = { path = "../pint/pint-pkg" }
 hex = "0.4.3"
 reqwest = "0.12.8"
 rpassword = "7.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ essential-signer = "0.4.0"
 essential-types = "0.5.0"
 essential-wallet = "0.5.0"
 pint-abi = "0.9.0"
-pint-cli = { path = "../pint/pint-cli" }
-pint-pkg = { path = "../pint/pint-pkg" }
+pint-cli = "0.11.0"
+pint-pkg = "0.11.0"
 hex = "0.4.3"
 reqwest = "0.12.8"
 rpassword = "7.3.1"

--- a/crates/pint-deploy/Cargo.toml
+++ b/crates/pint-deploy/Cargo.toml
@@ -11,7 +11,10 @@ repository.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+essential-hash = { workspace = true }
 essential-rest-client = { workspace = true }
 essential-types = { workspace = true }
+pint-cli = { workspace = true }
+pint-pkg = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/pint-deploy/src/main.rs
+++ b/crates/pint-deploy/src/main.rs
@@ -1,43 +1,129 @@
-use clap::Parser;
+use anyhow::{anyhow, bail, Context};
+use clap::{builder::styling::Style, Parser};
 use essential_rest_client::builder_client::EssentialBuilderClient;
-use essential_types::contract::Contract;
-use std::path::PathBuf;
+use essential_types::{contract::Contract, ContentAddress};
+use pint_pkg::build::BuiltPkg;
+use std::path::{Path, PathBuf};
 
 #[derive(Parser, Debug)]
-#[command(version, about, long_about = None)]
+#[command(name = "deploy", version, about, long_about = None)]
+#[group(skip)]
 /// Tool to deploy a contract to a Essential builder endpoint.
 struct Args {
-    /// The endpoint of builder to bind to.
+    // `pint deploy` builds too, so accepts all args that
+    #[command(flatten)]
+    build_args: pint_cli::build::Args,
+    /// The builder to which the contract deployment solution will be submitted.
     #[arg(long)]
     builder_address: String,
-    /// Path to the contract file as a json `Contract`.
+    /// Path to a specific `Contract` encoded as JSON.
+    ///
+    /// If a specific contract is specified in this manner, all arguments related to building a
+    /// pint project are ignored.
     #[arg(long)]
-    contract: PathBuf,
+    contract: Option<PathBuf>,
 }
 
 #[tokio::main]
 async fn main() {
     let args = Args::parse();
     if let Err(err) = run(args).await {
-        eprintln!("Command failed because: {}", err);
+        let bold = Style::new().bold();
+        eprintln!("{}Error:{} {err:?}", bold.render(), bold.render_reset());
+        std::process::exit(1);
     }
 }
 
 async fn run(args: Args) -> anyhow::Result<()> {
     let Args {
+        build_args,
         builder_address,
         contract,
     } = args;
 
     let builder_client = EssentialBuilderClient::new(builder_address)?;
-    let contract = serde_json::from_str::<Contract>(&from_file(contract).await?)?;
-    let output = builder_client.deploy_contract(&contract).await?;
-    println!("{}", output);
+
+    // If a contract was specified directly, there's no need to do the build or inspect any of the
+    // `build_args` - we can deploy this directly.
+    if let Some(contract_path) = contract {
+        let contract = contract_from_path(&contract_path).await?;
+        let name = format!(
+            "{}",
+            contract_path
+                .canonicalize()
+                .unwrap_or_else(|_| contract_path.to_path_buf())
+                .display()
+        );
+        print_deploying(&name, &contract);
+        let output = builder_client.deploy_contract(&contract).await?;
+        print_received(&output);
+        return Ok(());
+    }
+
+    // Otherwise, we should find and build the project.
+    let (plan, built_pkgs) = pint_cli::build::cmd(build_args)?;
+
+    // FIXME: We assume the package containing the output artifact is the last one in the
+    // compilation order. When supporting workspaces, we should deploy all (non-deployed) member
+    // "output" nodes in order of dependency.
+    let &n = plan
+        .compilation_order()
+        .last()
+        .ok_or_else(|| anyhow!("No built packages to deploy"))?;
+    let built = &built_pkgs[&n];
+    let pinned = &plan.graph()[n];
+    let manifest = &plan.manifests()[&pinned.id()];
+
+    // Now that the project is built, find the contract output.
+    // FIXME: Right now assume the `debug` profile just like the `build` command does.
+    let out_dir = manifest.out_dir();
+    let profile = "debug";
+    let profile_dir = out_dir.join(profile);
+    match built {
+        BuiltPkg::Library(_) => {
+            bail!("Expected a contract to deploy, but the pint package is a library")
+        }
+        BuiltPkg::Contract(_built) => {
+            let contract_path = profile_dir.join(&pinned.name).with_extension("json");
+            let contract = contract_from_path(&contract_path).await?;
+            print_deploying(&pinned.name, &contract);
+            let output = builder_client.deploy_contract(&contract).await?;
+            print_received(&output);
+        }
+    }
+
     Ok(())
 }
 
-/// Read file contents to a string.
-async fn from_file(path: PathBuf) -> anyhow::Result<String> {
-    let content = tokio::fs::read_to_string(path).await?;
-    Ok(content)
+/// Print the "Deploying ..." output with nice, aligned formatting.
+fn print_deploying(name: &str, contract: &Contract) {
+    let bold = Style::new().bold();
+    println!(
+        "   {}Deploying{} {} {}",
+        bold.render(),
+        bold.render_reset(),
+        name,
+        essential_hash::content_addr(contract),
+    );
+}
+
+/// Print the "Received ..." output.
+fn print_received(ca: &ContentAddress) {
+    let bold = Style::new().bold();
+    println!(
+        "    {}Received{} solution address {}",
+        bold.render(),
+        bold.render_reset(),
+        ca
+    );
+}
+
+/// Read a [`Contract`] from a JSON file at the given path.
+async fn contract_from_path(contract_path: &Path) -> anyhow::Result<Contract> {
+    let contract_string = tokio::fs::read_to_string(&contract_path)
+        .await
+        .with_context(|| format!("failed to read contract from file {contract_path:?}"))?;
+    let contract = serde_json::from_str::<Contract>(&contract_string)
+        .with_context(|| format!("failed to parse `Contract` from JSON {contract_path:?}"))?;
+    Ok(contract)
 }

--- a/crates/pint-deploy/src/main.rs
+++ b/crates/pint-deploy/src/main.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 #[group(skip)]
 /// Tool to deploy a contract to a Essential builder endpoint.
 struct Args {
-    // `pint deploy` builds too, so accepts all args that
+    // `pint deploy` builds too, so accepts all args that `pint build` does.
     #[command(flatten)]
     build_args: pint_cli::build::Args,
     /// The builder to which the contract deployment solution will be submitted.

--- a/crates/pint-deploy/src/main.rs
+++ b/crates/pint-deploy/src/main.rs
@@ -18,7 +18,7 @@ struct Args {
     builder_address: String,
     /// Path to a specific `Contract` encoded as JSON.
     ///
-    /// If a specific contract is specified in this manner, all arguments related to building a
+    /// If a contract is specified in this manner, all arguments related to building a
     /// pint project are ignored.
     #[arg(long)]
     contract: Option<PathBuf>,


### PR DESCRIPTION
## To-Do

- [x] Land and publish changes in https://github.com/essential-contributions/pint/pull/995.
- [x] Update toml to point to latest `pint-pkg`, `pint-cli`.

Closes https://github.com/essential-contributions/essential-integration/issues/123

## Follow-up

- https://github.com/essential-contributions/essential-integration/issues/129