### PR TITLE
feat: check submitted solution CA against attemped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2313,6 +2313,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "essential-hash 0.7.0",
  "essential-rest-client",
  "essential-types 0.5.0",
  "hex",

--- a/crates/pint-submit/Cargo.toml
+++ b/crates/pint-submit/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
+essential-hash = { workspace = true }
 essential-rest-client = { workspace = true }
 essential-types = { workspace = true }
 hex = { workspace = true }


### PR DESCRIPTION
```
bash-5.2$ pint deploy --builder-address http://0.0.0.0:3554
   Compiling pint [contract] (/Users/tokamak/essential/essential-integration/apps/counter/pint)
    Finished build [debug] in 2.2065ms
    contract pint            1899743AA94972DDD137D039C2E670ADA63969ABF93191FA1A4506304D4033A2
         └── pint::Increment 355A12DCB600C302FFD5D69C4B7B79E60BA3C72DDA553B7D43F4C36CB7CC0948
   Deploying pint 1899743AA94972DDD137D039C2E670ADA63969ABF93191FA1A4506304D4033A2
    Received solution address 1FD5247B6DBB3C79CA875FD54894F71F0840F38E469D5A2270BD8AE02FBF22FA
bash-5.2$ pint submit --builder-address http://0.0.0.0:3554 --solution ./solution.json
  Submitting solution 68A1BC8E7A5E6789E8DE4BC59A7ADD0BFC5AF7FA591FCC03CEBE6E4754C13CA1
   Submitted successfully
```

Closes #129 