### PR TITLE
refactor: use convert util for `Key`s in CLIs

### DIFF
--- a/apps/counter/app/src/lib.rs
+++ b/apps/counter/app/src/lib.rs
@@ -1,7 +1,7 @@
 use anyhow::bail;
 use essential_types::{
     solution::{Mutation, Solution},
-    PredicateAddress, Value, Word,
+    Key, PredicateAddress, Value, Word,
 };
 
 /// The location in storage where the counter is stored.
@@ -9,7 +9,7 @@ const COUNTER_KEY: Word = 0;
 
 #[derive(Clone)]
 /// The key used to access the counter in storage.
-pub struct CounterKey(pub Vec<Word>);
+pub struct CounterKey(pub Key);
 
 #[derive(Clone)]
 /// The data returned when querying the current count.

--- a/docs/code/counter-main.rs
+++ b/docs/code/counter-main.rs
@@ -95,7 +95,7 @@ async fn query_count(
     address: ContentAddress,
     key: CounterKey,
 ) -> anyhow::Result<Option<Value>> {
-    Ok(node.query_state(address, key.0).await?)
+    Ok(node.query_state(address, key).await?)
 }
 // ANCHOR_END: qry
 


### PR DESCRIPTION
The base crate now has a util for converting (vector/slice of `Word`s <-> hex string). 

This PR removes the workaround of wrapping `Key` in another type and implementing `FromStr` for the wrapper type.

Followup to https://github.com/essential-contributions/essential-base/pull/230

CI will fail until a new version of `essential-base` is released and the dependency is updated in this PR.