### PR TITLE
Reuse pint-submit in pint-deploy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2174,6 +2174,7 @@ dependencies = [
  "anyhow",
  "clap",
  "essential-hash 0.9.0",
+ "essential-node-types",
  "essential-rest-client",
  "essential-types 0.7.0",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2103,6 +2103,7 @@ dependencies = [
  "essential-types 0.7.0",
  "pint-cli",
  "pint-pkg",
+ "pint-submit",
  "serde_json",
  "tokio",
 ]

--- a/apps/counter/app/src/main.rs
+++ b/apps/counter/app/src/main.rs
@@ -67,7 +67,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             let solutions = SolutionSet {
                 solutions: vec![solution],
             };
-            let ca = builder.submit_solution(&solutions).await?;
+            let ca = builder.submit_solution_set(&solutions).await?;
             println!("Submitted solution: {}", ca);
             println!("Incremented count to: {}", new_count);
         }

--- a/apps/token/app/src/main.rs
+++ b/apps/token/app/src/main.rs
@@ -239,7 +239,7 @@ async fn mint(mut wallet: Wallet, args: Mint) -> anyhow::Result<ContentAddress> 
     let solutions = SolutionSet {
         solutions: vec![solution],
     };
-    let ca = builder.submit_solution(&solutions).await?;
+    let ca = builder.submit_solution_set(&solutions).await?;
     Ok(ca)
 }
 
@@ -285,7 +285,7 @@ async fn burn(mut wallet: Wallet, args: Burn) -> anyhow::Result<ContentAddress> 
     let solutions = SolutionSet {
         solutions: vec![solution],
     };
-    let ca = builder.submit_solution(&solutions).await?;
+    let ca = builder.submit_solution_set(&solutions).await?;
     Ok(ca)
 }
 
@@ -344,7 +344,7 @@ async fn transfer(mut wallet: Wallet, args: Transfer) -> anyhow::Result<ContentA
     let solutions = SolutionSet {
         solutions: vec![solution],
     };
-    let ca = builder.submit_solution(&solutions).await?;
+    let ca = builder.submit_solution_set(&solutions).await?;
     Ok(ca)
 }
 

--- a/crates/essential-rest-client/src/builder_client.rs
+++ b/crates/essential-rest-client/src/builder_client.rs
@@ -42,7 +42,7 @@ impl EssentialBuilderClient {
                 .map(|p| register_program_solution(big_bang.program_registry.clone(), p)),
         );
         let solutions = SolutionSet { solutions };
-        self.submit_solution(&solutions).await
+        self.submit_solution_set(&solutions).await
     }
 
     /// Submit solution.
@@ -61,7 +61,7 @@ impl EssentialBuilderClient {
     /// Submitting the same solution twice (even by different user) is idempotent.
     ///
     /// Returns the content address of the submitted solution.
-    pub async fn submit_solution(&self, solutions: &SolutionSet) -> anyhow::Result<ContentAddress> {
+    pub async fn submit_solution_set(&self, solutions: &SolutionSet) -> anyhow::Result<ContentAddress> {
         let url = self.url.join("/submit-solution-set")?;
         let response = handle_response(self.client.post(url).json(solutions).send().await?).await?;
         dbg!(&response);

--- a/crates/essential-rest-client/src/builder_client.rs
+++ b/crates/essential-rest-client/src/builder_client.rs
@@ -61,7 +61,10 @@ impl EssentialBuilderClient {
     /// Submitting the same solution twice (even by different user) is idempotent.
     ///
     /// Returns the content address of the submitted solution.
-    pub async fn submit_solution_set(&self, solutions: &SolutionSet) -> anyhow::Result<ContentAddress> {
+    pub async fn submit_solution_set(
+        &self,
+        solutions: &SolutionSet,
+    ) -> anyhow::Result<ContentAddress> {
         let url = self.url.join("/submit-solution-set")?;
         let response = handle_response(self.client.post(url).json(solutions).send().await?).await?;
         dbg!(&response);

--- a/crates/essential-rest-client/src/main.rs
+++ b/crates/essential-rest-client/src/main.rs
@@ -117,7 +117,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             let solutions = SolutionSet {
                 solutions: vec![solution],
             };
-            let output = builder_client.submit_solution(&solutions).await?;
+            let output = builder_client.submit_solution_set(&solutions).await?;
             println!("{}", output);
         }
         Command::LatestSolutionFailures {

--- a/crates/pint-deploy/Cargo.toml
+++ b/crates/pint-deploy/Cargo.toml
@@ -17,6 +17,6 @@ essential-rest-client = { workspace = true }
 essential-types = { workspace = true }
 pint-cli = { workspace = true }
 pint-pkg = { workspace = true }
-pint-submit = { workapace = true }
+pint-submit = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/pint-deploy/Cargo.toml
+++ b/crates/pint-deploy/Cargo.toml
@@ -17,6 +17,6 @@ essential-rest-client = { workspace = true }
 essential-types = { workspace = true }
 pint-cli = { workspace = true }
 pint-pkg = { workspace = true }
-pint-submit = { path = "../pint-submit" }
+pint-submit = { workapace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/pint-deploy/Cargo.toml
+++ b/crates/pint-deploy/Cargo.toml
@@ -17,5 +17,6 @@ essential-rest-client = { workspace = true }
 essential-types = { workspace = true }
 pint-cli = { workspace = true }
 pint-pkg = { workspace = true }
+pint-submit = { path = "../pint-submit" }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/pint-deploy/src/main.rs
+++ b/crates/pint-deploy/src/main.rs
@@ -1,11 +1,11 @@
 use anyhow::{anyhow, bail};
 use clap::{builder::styling::Style, Parser};
 use essential_rest_client::{builder_client::EssentialBuilderClient, contract_from_path};
-use essential_node_types::{BigBang, register_contract_solution};
+use essential_node_types::BigBang;
 use essential_types::{contract::Contract, ContentAddress};
 use pint_pkg::build::BuiltPkg;
 use pint_submit::submit_solution;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
 #[command(name = "deploy", version, about, long_about = None)]
@@ -47,7 +47,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
     // FIXME: Provide CLI arg for specifying a path to a yml like the node and builder.
     let big_bang = BigBang::default();
 
-    let builder_client = EssentialBuilderClient::new(builder_address)?;
+    let builder_client = EssentialBuilderClient::new(builder_address.clone())?;
 
     // If a contract was specified directly, there's no need to do the build or inspect any of the
     // `build_args` - we can deploy this directly.
@@ -66,7 +66,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
             .deploy_contract(&big_bang, &contract, &programs)
             .await?;
         print_received(&output);
-        submit(contract, &builder_address.clone()).await?;
+        submit(&contract, &builder_address.clone()).await?;
         return Ok(());
     }
 
@@ -102,7 +102,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
                 .deploy_contract(&big_bang, &contract, &programs)
                 .await?;
             print_received(&output);
-            submit(contract, &builder_address).await?;
+            submit(&contract, &builder_address).await?;
         }
     }
 

--- a/crates/pint-deploy/src/main.rs
+++ b/crates/pint-deploy/src/main.rs
@@ -4,7 +4,8 @@ use essential_node_types::BigBang;
 use essential_rest_client::{builder_client::EssentialBuilderClient, contract_from_path};
 use essential_types::{contract::Contract, ContentAddress};
 use pint_pkg::build::BuiltPkg;
-use std::path::PathBuf;
+use pint_submit::SolutionInputType;
+use std::path::{Path, PathBuf};
 
 #[derive(Parser, Debug)]
 #[command(name = "deploy", version, about, long_about = None)]

--- a/crates/pint-deploy/src/main.rs
+++ b/crates/pint-deploy/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, bail};
 use clap::{builder::styling::Style, Parser};
-use essential_rest_client::{builder_client::EssentialBuilderClient, contract_from_path};
 use essential_node_types::BigBang;
+use essential_rest_client::{builder_client::EssentialBuilderClient, contract_from_path};
 use essential_types::{contract::Contract, ContentAddress};
 use pint_pkg::build::BuiltPkg;
 use pint_submit::submit_solution;

--- a/crates/pint-deploy/src/main.rs
+++ b/crates/pint-deploy/src/main.rs
@@ -4,7 +4,7 @@ use essential_node_types::BigBang;
 use essential_rest_client::{builder_client::EssentialBuilderClient, contract_from_path};
 use essential_types::{contract::Contract, ContentAddress};
 use pint_pkg::build::BuiltPkg;
-use pint_submit::submit_solution_set;
+use pint_submit::register_contract;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -66,7 +66,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
             .deploy_contract(&big_bang, &contract, &programs)
             .await?;
         print_received(&output);
-        submit(&contract, builder_address).await?;
+        register_contract_and_submit_solution(builder_address, &contract).await?;
         return Ok(());
     }
 
@@ -102,15 +102,18 @@ async fn run(args: Args) -> anyhow::Result<()> {
                 .deploy_contract(&big_bang, &contract, &programs)
                 .await?;
             print_received(&output);
-            submit(&contract, builder_address).await?;
+            register_contract_and_submit_solution(builder_address, &contract).await?;
         }
     }
 
     Ok(())
 }
 
-async fn submit(contract: &Contract, builder_address: String) -> Result<(), anyhow::Error> {
-    let output = submit_solution_set(None, builder_address, Some(contract)).await?;
+async fn register_contract_and_submit_solution(
+    builder_address: String,
+    contract: &Contract,
+) -> Result<(), anyhow::Error> {
+    let output = register_contract(builder_address, contract).await?;
     print_received(&output);
     Ok(())
 }

--- a/crates/pint-deploy/src/main.rs
+++ b/crates/pint-deploy/src/main.rs
@@ -4,7 +4,7 @@ use essential_rest_client::{builder_client::EssentialBuilderClient, contract_fro
 use essential_node_types::{BigBang, register_contract_solution};
 use essential_types::{contract::Contract, ContentAddress};
 use pint_pkg::build::BuiltPkg;
-use pint_submit::{submit_solution, SolutionInputType};
+use pint_submit::submit_solution;
 use std::path::{Path, PathBuf};
 
 #[derive(Parser, Debug)]
@@ -43,15 +43,12 @@ async fn run(args: Args) -> anyhow::Result<()> {
         contract,
     } = args;
 
-<<<<<<< HEAD
     // The expected configuration of the chain we're querying.
     // FIXME: Provide CLI arg for specifying a path to a yml like the node and builder.
     let big_bang = BigBang::default();
 
     let builder_client = EssentialBuilderClient::new(builder_address)?;
 
-=======
->>>>>>> 1a1bff2 (refactor: extract and use fn submit() in pint-deploy)
     // If a contract was specified directly, there's no need to do the build or inspect any of the
     // `build_args` - we can deploy this directly.
     if let Some(contract_path) = contract {
@@ -64,14 +61,12 @@ async fn run(args: Args) -> anyhow::Result<()> {
                 .display()
         );
         print_deploying(&name, &contract);
-<<<<<<< HEAD
+
         let output = builder_client
             .deploy_contract(&big_bang, &contract, &programs)
             .await?;
         print_received(&output);
-=======
         submit(contract, &builder_address.clone()).await?;
->>>>>>> 1a1bff2 (refactor: extract and use fn submit() in pint-deploy)
         return Ok(());
     }
 
@@ -102,25 +97,20 @@ async fn run(args: Args) -> anyhow::Result<()> {
             let contract_path = profile_dir.join(&pinned.name).with_extension("json");
             let (contract, programs) = contract_from_path(&contract_path).await?;
             print_deploying(&pinned.name, &contract);
-<<<<<<< HEAD
+
             let output = builder_client
                 .deploy_contract(&big_bang, &contract, &programs)
                 .await?;
             print_received(&output);
-=======
             submit(contract, &builder_address).await?;
->>>>>>> 1a1bff2 (refactor: extract and use fn submit() in pint-deploy)
         }
     }
 
     Ok(())
 }
 
-async fn submit(contract: Contract, builder_address: &String) -> Result<(), anyhow::Error> {
-    let registry_predicate = essential_node_types::BigBang::default().contract_registry;
-    let solution = register_contract_solution(registry_predicate, &contract)?;
-    let solution_input = SolutionInputType::Json(serde_json::to_string(&solution)?);
-    let output = submit_solution(builder_address.clone().to_string(), solution_input).await?;
+async fn submit(contract: &Contract, builder_address: &str) -> Result<(), anyhow::Error> {
+    let output = submit_solution(None, builder_address.to_string(), Some(contract)).await?;
     print_received(&output);
     Ok(())
 }

--- a/crates/pint-deploy/src/main.rs
+++ b/crates/pint-deploy/src/main.rs
@@ -4,7 +4,7 @@ use essential_node_types::BigBang;
 use essential_rest_client::{builder_client::EssentialBuilderClient, contract_from_path};
 use essential_types::{contract::Contract, ContentAddress};
 use pint_pkg::build::BuiltPkg;
-use pint_submit::submit_solution;
+use pint_submit::submit_solution_set;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -110,7 +110,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
 }
 
 async fn submit(contract: &Contract, builder_address: String) -> Result<(), anyhow::Error> {
-    let output = submit_solution(None, builder_address, Some(contract)).await?;
+    let output = submit_solution_set(None, builder_address, Some(contract)).await?;
     print_received(&output);
     Ok(())
 }

--- a/crates/pint-deploy/src/main.rs
+++ b/crates/pint-deploy/src/main.rs
@@ -1,10 +1,10 @@
 use anyhow::{anyhow, bail};
 use clap::{builder::styling::Style, Parser};
-use essential_node_types::BigBang;
 use essential_rest_client::{builder_client::EssentialBuilderClient, contract_from_path};
+use essential_node_types::{BigBang, register_contract_solution};
 use essential_types::{contract::Contract, ContentAddress};
 use pint_pkg::build::BuiltPkg;
-use pint_submit::SolutionInputType;
+use pint_submit::{submit_solution, SolutionInputType};
 use std::path::{Path, PathBuf};
 
 #[derive(Parser, Debug)]
@@ -43,12 +43,15 @@ async fn run(args: Args) -> anyhow::Result<()> {
         contract,
     } = args;
 
+<<<<<<< HEAD
     // The expected configuration of the chain we're querying.
     // FIXME: Provide CLI arg for specifying a path to a yml like the node and builder.
     let big_bang = BigBang::default();
 
     let builder_client = EssentialBuilderClient::new(builder_address)?;
 
+=======
+>>>>>>> 1a1bff2 (refactor: extract and use fn submit() in pint-deploy)
     // If a contract was specified directly, there's no need to do the build or inspect any of the
     // `build_args` - we can deploy this directly.
     if let Some(contract_path) = contract {
@@ -61,10 +64,14 @@ async fn run(args: Args) -> anyhow::Result<()> {
                 .display()
         );
         print_deploying(&name, &contract);
+<<<<<<< HEAD
         let output = builder_client
             .deploy_contract(&big_bang, &contract, &programs)
             .await?;
         print_received(&output);
+=======
+        submit(contract, &builder_address.clone()).await?;
+>>>>>>> 1a1bff2 (refactor: extract and use fn submit() in pint-deploy)
         return Ok(());
     }
 
@@ -95,13 +102,26 @@ async fn run(args: Args) -> anyhow::Result<()> {
             let contract_path = profile_dir.join(&pinned.name).with_extension("json");
             let (contract, programs) = contract_from_path(&contract_path).await?;
             print_deploying(&pinned.name, &contract);
+<<<<<<< HEAD
             let output = builder_client
                 .deploy_contract(&big_bang, &contract, &programs)
                 .await?;
             print_received(&output);
+=======
+            submit(contract, &builder_address).await?;
+>>>>>>> 1a1bff2 (refactor: extract and use fn submit() in pint-deploy)
         }
     }
 
+    Ok(())
+}
+
+async fn submit(contract: Contract, builder_address: &String) -> Result<(), anyhow::Error> {
+    let registry_predicate = essential_node_types::BigBang::default().contract_registry;
+    let solution = register_contract_solution(registry_predicate, &contract)?;
+    let solution_input = SolutionInputType::Json(serde_json::to_string(&solution)?);
+    let output = submit_solution(builder_address.clone().to_string(), solution_input).await?;
+    print_received(&output);
     Ok(())
 }
 

--- a/crates/pint-deploy/src/main.rs
+++ b/crates/pint-deploy/src/main.rs
@@ -66,7 +66,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
             .deploy_contract(&big_bang, &contract, &programs)
             .await?;
         print_received(&output);
-        submit(&contract, &builder_address.clone()).await?;
+        submit(&contract, builder_address).await?;
         return Ok(());
     }
 
@@ -102,15 +102,15 @@ async fn run(args: Args) -> anyhow::Result<()> {
                 .deploy_contract(&big_bang, &contract, &programs)
                 .await?;
             print_received(&output);
-            submit(&contract, &builder_address).await?;
+            submit(&contract, builder_address).await?;
         }
     }
 
     Ok(())
 }
 
-async fn submit(contract: &Contract, builder_address: &str) -> Result<(), anyhow::Error> {
-    let output = submit_solution(None, builder_address.to_string(), Some(contract)).await?;
+async fn submit(contract: &Contract, builder_address: String) -> Result<(), anyhow::Error> {
+    let output = submit_solution(None, builder_address, Some(contract)).await?;
     print_received(&output);
     Ok(())
 }

--- a/crates/pint-submit/Cargo.toml
+++ b/crates/pint-submit/Cargo.toml
@@ -15,11 +15,11 @@ path = "src/main.rs"
 [lib]
 path = "src/lib.rs"
 
-
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
 essential-hash = { workspace = true }
+essential-node-types = { workspace = true }
 essential-rest-client = { workspace = true }
 essential-types = { workspace = true }
 hex = { workspace = true }

--- a/crates/pint-submit/Cargo.toml
+++ b/crates/pint-submit/Cargo.toml
@@ -8,6 +8,14 @@ homepage.workspace = true
 license.workspace = true
 repository.workspace = true
 
+[[bin]]
+name = "submit"
+path = "src/main.rs"
+
+[lib]
+path = "src/lib.rs"
+
+
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }

--- a/crates/pint-submit/src/lib.rs
+++ b/crates/pint-submit/src/lib.rs
@@ -16,7 +16,10 @@ pub async fn solution_from_input(solution: SolutionInputType) -> Result<Solution
     Ok(serde_json::from_str(&solution)?)
 }
 
-pub async fn submit_solution(builder_address: String, solution_input: SolutionInputType) -> anyhow::Result<ContentAddress> {
+pub async fn submit_solution(
+    builder_address: String,
+    solution_input: SolutionInputType,
+) -> anyhow::Result<ContentAddress> {
     let builder_client = EssentialBuilderClient::new(builder_address)?;
     let solution = solution_from_input(solution_input).await?;
     let solution_ca = essential_hash::content_addr(&solution);

--- a/crates/pint-submit/src/lib.rs
+++ b/crates/pint-submit/src/lib.rs
@@ -1,0 +1,20 @@
+use essential_types::solution::Solution;
+use std::path::PathBuf;
+
+pub enum SolutionInputType {
+    Path(PathBuf),
+    Json(String),
+}
+
+pub async fn solution_from_input(solution: SolutionInputType) -> Result<Solution, anyhow::Error> {
+    let solution = match solution {
+        SolutionInputType::Path(path) => from_file(path).await?,
+        SolutionInputType::Json(json) => json,
+    };
+    Ok(serde_json::from_str(&solution)?)
+}
+
+async fn from_file(path: PathBuf) -> anyhow::Result<String> {
+    let content = tokio::fs::read_to_string(path).await?;
+    Ok(content)
+}

--- a/crates/pint-submit/src/lib.rs
+++ b/crates/pint-submit/src/lib.rs
@@ -1,4 +1,5 @@
 use clap::builder::styling::Style;
+use essential_rest_client::builder_client::EssentialBuilderClient;
 use essential_types::{solution::Solution, ContentAddress};
 use std::path::PathBuf;
 
@@ -13,6 +14,19 @@ pub async fn solution_from_input(solution: SolutionInputType) -> Result<Solution
         SolutionInputType::Json(json) => json,
     };
     Ok(serde_json::from_str(&solution)?)
+}
+
+pub async fn submit_solution(builder_address: String, solution_input: SolutionInputType) -> anyhow::Result<ContentAddress> {
+    let builder_client = EssentialBuilderClient::new(builder_address)?;
+    let solution = solution_from_input(solution_input).await?;
+    let solution_ca = essential_hash::content_addr(&solution);
+    print_submitting(&solution_ca);
+    let output = builder_client.submit_solution(&solution).await?;
+    if solution_ca != output {
+        anyhow::bail!("The content address of the submitted solution differs from expected. May be a serialization error.");
+    }
+    print_submitted();
+    Ok(output)
 }
 
 async fn from_file(path: PathBuf) -> anyhow::Result<String> {

--- a/crates/pint-submit/src/lib.rs
+++ b/crates/pint-submit/src/lib.rs
@@ -13,10 +13,10 @@ pub async fn submit_solution(
         (Some(s), None) => serde_json::from_str::<SolutionSet>(&from_file(s).await?)?,
         (None, Some(contract)) => {
             let registry_predicate = essential_node_types::BigBang::default().contract_registry;
-            let solution = register_contract_solution(registry_predicate, contract)
-                ?;
+            let solution = register_contract_solution(registry_predicate, contract)?;
             SolutionSet {
-                solutions: vec![solution]}
+                solutions: vec![solution],
+            }
         }
         (None, None) | (Some(_), Some(_)) => {
             anyhow::bail!("Either a solution or a contract must be provided, but not both.");

--- a/crates/pint-submit/src/lib.rs
+++ b/crates/pint-submit/src/lib.rs
@@ -31,7 +31,7 @@ pub async fn submit_solution(
     let builder_client = EssentialBuilderClient::new(builder_address)?;
     let solution_ca = essential_hash::content_addr(&solution_set);
     print_submitting(&solution_ca);
-    let output = builder_client.submit_solution(&solution_set).await?;
+    let output = builder_client.submit_solution_set(&solution_set).await?;
     if solution_ca != output {
         anyhow::bail!("The content address of the submitted solution differs from expected. May be a serialization error.");
     }

--- a/crates/pint-submit/src/lib.rs
+++ b/crates/pint-submit/src/lib.rs
@@ -1,4 +1,5 @@
-use essential_types::solution::Solution;
+use clap::builder::styling::Style;
+use essential_types::{solution::Solution, ContentAddress};
 use std::path::PathBuf;
 
 pub enum SolutionInputType {
@@ -17,4 +18,25 @@ pub async fn solution_from_input(solution: SolutionInputType) -> Result<Solution
 async fn from_file(path: PathBuf) -> anyhow::Result<String> {
     let content = tokio::fs::read_to_string(path).await?;
     Ok(content)
+}
+
+/// Print the "Submitting ..." output.
+pub fn print_submitting(ca: &ContentAddress) {
+    let bold = Style::new().bold();
+    println!(
+        "  {}Submitting{} solution {}",
+        bold.render(),
+        bold.render_reset(),
+        ca,
+    );
+}
+
+/// Print the "Submitted" output.
+pub fn print_submitted() {
+    let bold = Style::new().bold();
+    println!(
+        "   {}Submitted{} successfully",
+        bold.render(),
+        bold.render_reset(),
+    );
 }

--- a/crates/pint-submit/src/lib.rs
+++ b/crates/pint-submit/src/lib.rs
@@ -9,8 +9,13 @@ pub async fn submit_solution(
     builder_address: String,
     contract_opt: Option<&Contract>,
 ) -> anyhow::Result<ContentAddress> {
+    // Used by both `pint-submit` and `pint-deploy`.
+    // For the former, we receive a path to a solution,
+    // whereas for the latter we receive a reference to a contract.
     let solution_set: SolutionSet = match (solutions_opt, contract_opt) {
+        // handle `pint-submit`
         (Some(s), None) => serde_json::from_str::<SolutionSet>(&from_file(s).await?)?,
+        // handle `pint-deploy`
         (None, Some(contract)) => {
             let registry_predicate = essential_node_types::BigBang::default().contract_registry;
             let solution = register_contract_solution(registry_predicate, contract)?;
@@ -24,7 +29,6 @@ pub async fn submit_solution(
     };
 
     let builder_client = EssentialBuilderClient::new(builder_address)?;
-    // let solution_set = serde_json::from_str::<SolutionSet>(&from_file(solutions).await?)?;
     let solution_ca = essential_hash::content_addr(&solution_set);
     print_submitting(&solution_ca);
     let output = builder_client.submit_solution(&solution_set).await?;

--- a/crates/pint-submit/src/lib.rs
+++ b/crates/pint-submit/src/lib.rs
@@ -4,7 +4,7 @@ use essential_rest_client::builder_client::EssentialBuilderClient;
 use essential_types::{contract::Contract, solution::SolutionSet, ContentAddress};
 use std::path::PathBuf;
 
-pub async fn submit_solution(
+pub async fn submit_solution_set(
     solutions_opt: Option<PathBuf>,
     builder_address: String,
     contract_opt: Option<&Contract>,
@@ -38,6 +38,10 @@ pub async fn submit_solution(
     print_submitted();
     Ok(output)
 }
+
+pub async fn register_contract() {}
+
+pub async fn register_program() {}
 
 async fn from_file(path: PathBuf) -> anyhow::Result<String> {
     let content = tokio::fs::read_to_string(path).await?;

--- a/crates/pint-submit/src/main.rs
+++ b/crates/pint-submit/src/main.rs
@@ -1,7 +1,7 @@
-use clap::{builder::styling::Style, Parser};
+use clap::Parser;
 use essential_rest_client::builder_client::EssentialBuilderClient;
 use essential_types::{solution::SolutionSet, ContentAddress};
-use pint_submit::{solution_from_input, SolutionInputType};
+use pint_submit::{print_submitted, print_submitting, solution_from_input, SolutionInputType};
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -41,25 +41,4 @@ async fn run(args: Args) -> anyhow::Result<()> {
     }
     print_submitted();
     Ok(())
-}
-
-/// Print the "Submitting ..." output.
-fn print_submitting(ca: &ContentAddress) {
-    let bold = Style::new().bold();
-    println!(
-        "  {}Submitting{} solution set {}",
-        bold.render(),
-        bold.render_reset(),
-        ca,
-    );
-}
-
-/// Print the "Submitted" output.
-fn print_submitted() {
-    let bold = Style::new().bold();
-    println!(
-        "   {}Submitted{} successfully",
-        bold.render(),
-        bold.render_reset(),
-    );
 }

--- a/crates/pint-submit/src/main.rs
+++ b/crates/pint-submit/src/main.rs
@@ -1,7 +1,5 @@
 use clap::Parser;
-use essential_rest_client::builder_client::EssentialBuilderClient;
-use essential_types::{solution::SolutionSet, ContentAddress};
-use pint_submit::{print_submitted, print_submitting, solution_from_input, SolutionInputType, submit_solution};
+use pint_submit::submit_solution;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -30,18 +28,6 @@ async fn run(args: Args) -> anyhow::Result<()> {
         solutions,
     } = args;
 
-    let builder_client = EssentialBuilderClient::new(builder_address)?;
-    let solution_set = serde_json::from_str::<SolutionSet>(&from_file(solutions).await?)?;
-    let solution_ca = essential_hash::content_addr(&solution_set);
-    let solution_input = SolutionInputType::Path(solution);
-    print_submitting(&solution_ca);
-    let output = builder_client.submit_solution(&solution_set).await?;
-    if solution_ca != output {
-        anyhow::bail!("The content address of the submitted solution set differs from expected. May be a serialization error.");
-    }
-    print_submitted();
-
-    let solution_input = SolutionInputType::Path(solution);
-    submit_solution(Some(solution), builder_address, None).await?;
+    submit_solution(Some(solutions), builder_address, None).await?;
     Ok(())
 }

--- a/crates/pint-submit/src/main.rs
+++ b/crates/pint-submit/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use essential_rest_client::builder_client::EssentialBuilderClient;
 use essential_types::{solution::SolutionSet, ContentAddress};
-use pint_submit::{print_submitted, print_submitting, solution_from_input, SolutionInputType};
+use pint_submit::{print_submitted, print_submitting, solution_from_input, SolutionInputType, submit_solution};
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -30,6 +30,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
         solutions,
     } = args;
 
+<<<<<<< HEAD
     let builder_client = EssentialBuilderClient::new(builder_address)?;
     let solution_set = serde_json::from_str::<SolutionSet>(&from_file(solutions).await?)?;
     let solution_ca = essential_hash::content_addr(&solution_set);
@@ -40,5 +41,9 @@ async fn run(args: Args) -> anyhow::Result<()> {
         anyhow::bail!("The content address of the submitted solution set differs from expected. May be a serialization error.");
     }
     print_submitted();
+=======
+    let solution_input = SolutionInputType::Path(solution);
+    submit_solution(builder_address, solution_input).await?;
+>>>>>>> c4b0835 (refactor: extract fn submit_solution() from main to lib)
     Ok(())
 }

--- a/crates/pint-submit/src/main.rs
+++ b/crates/pint-submit/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use pint_submit::submit_solution;
+use pint_submit::submit_solution_set;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -28,6 +28,6 @@ async fn run(args: Args) -> anyhow::Result<()> {
         solutions,
     } = args;
 
-    submit_solution(Some(solutions), builder_address, None).await?;
+    submit_solution_set(Some(solutions), builder_address, None).await?;
     Ok(())
 }

--- a/crates/pint-submit/src/main.rs
+++ b/crates/pint-submit/src/main.rs
@@ -1,6 +1,7 @@
 use clap::{builder::styling::Style, Parser};
 use essential_rest_client::builder_client::EssentialBuilderClient;
 use essential_types::{solution::SolutionSet, ContentAddress};
+use pint_submit::{solution_from_input, SolutionInputType};
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -42,19 +43,6 @@ async fn run(args: Args) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub enum SolutionInputType {
-    Path(PathBuf),
-    Json(String),
-}
-
-async fn solution_from_input(solution: SolutionInputType) -> Result<Solution, anyhow::Error> {
-    let solution = match solution {
-        SolutionInputType::Path(path) => from_file(path).await?,
-        SolutionInputType::Json(json) => json,
-    };
-    Ok(serde_json::from_str(&solution)?)
-}
-
 /// Print the "Submitting ..." output.
 fn print_submitting(ca: &ContentAddress) {
     let bold = Style::new().bold();
@@ -74,9 +62,4 @@ fn print_submitted() {
         bold.render(),
         bold.render_reset(),
     );
-}
-
-async fn from_file(path: PathBuf) -> anyhow::Result<String> {
-    let content = tokio::fs::read_to_string(path).await?;
-    Ok(content)
 }

--- a/crates/pint-submit/src/main.rs
+++ b/crates/pint-submit/src/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use essential_types::solution::SolutionSet;
 use pint_submit::submit_solution_set;
 use std::path::PathBuf;
 
@@ -28,6 +29,8 @@ async fn run(args: Args) -> anyhow::Result<()> {
         solutions,
     } = args;
 
-    submit_solution_set(Some(solutions), builder_address, None).await?;
+    let solution_set =
+        serde_json::from_str::<SolutionSet>(tokio::fs::read_to_string(&solutions).await?.as_str())?;
+    submit_solution_set(solution_set, builder_address).await?;
     Ok(())
 }

--- a/crates/pint-submit/src/main.rs
+++ b/crates/pint-submit/src/main.rs
@@ -32,6 +32,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
     let builder_client = EssentialBuilderClient::new(builder_address)?;
     let solution_set = serde_json::from_str::<SolutionSet>(&from_file(solutions).await?)?;
     let solution_ca = essential_hash::content_addr(&solution_set);
+    let solution_input = SolutionInputType::Path(solution);
     print_submitting(&solution_ca);
     let output = builder_client.submit_solution(&solution_set).await?;
     if solution_ca != output {
@@ -39,6 +40,19 @@ async fn run(args: Args) -> anyhow::Result<()> {
     }
     print_submitted();
     Ok(())
+}
+
+pub enum SolutionInputType {
+    Path(PathBuf),
+    Json(String),
+}
+
+async fn solution_from_input(solution: SolutionInputType) -> Result<Solution, anyhow::Error> {
+    let solution = match solution {
+        SolutionInputType::Path(path) => from_file(path).await?,
+        SolutionInputType::Json(json) => json,
+    };
+    Ok(serde_json::from_str(&solution)?)
 }
 
 /// Print the "Submitting ..." output.

--- a/crates/pint-submit/src/main.rs
+++ b/crates/pint-submit/src/main.rs
@@ -30,7 +30,6 @@ async fn run(args: Args) -> anyhow::Result<()> {
         solutions,
     } = args;
 
-<<<<<<< HEAD
     let builder_client = EssentialBuilderClient::new(builder_address)?;
     let solution_set = serde_json::from_str::<SolutionSet>(&from_file(solutions).await?)?;
     let solution_ca = essential_hash::content_addr(&solution_set);
@@ -41,9 +40,8 @@ async fn run(args: Args) -> anyhow::Result<()> {
         anyhow::bail!("The content address of the submitted solution set differs from expected. May be a serialization error.");
     }
     print_submitted();
-=======
+
     let solution_input = SolutionInputType::Path(solution);
-    submit_solution(builder_address, solution_input).await?;
->>>>>>> c4b0835 (refactor: extract fn submit_solution() from main to lib)
+    submit_solution(Some(solution), builder_address, None).await?;
     Ok(())
 }


### PR DESCRIPTION
This pr splits `pint-submit` into a `bin` & a `lib` target. It then shares  common functionality in `lib` with `pint-deploy` to remove duplication of logic and provide an more consistent UX.

I've depended on `pint-submit` as a local dep (path) for now, not sure if we want to publish as it's own crate?
I don't think we need that now, but perhaps if it's ever needed for in-language testing or something.
