### PR TITLE
feat: Ensure `Program`s are deployed alongside their `Contract`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,7 @@ dependencies = [
  "essential-types 0.7.0",
  "regex",
  "tokio",
+ "tracing",
  "tracing-subscriber",
 ]
 
@@ -2247,6 +2248,7 @@ dependencies = [
  "anyhow",
  "clap",
  "essential-hash 0.9.0",
+ "essential-node-types",
  "essential-rest-client",
  "essential-types 0.7.0",
  "pint-cli",

--- a/apps/counter/app/Cargo.toml
+++ b/apps/counter/app/Cargo.toml
@@ -19,4 +19,5 @@ essential-builder.workspace = true
 essential-builder-db.workspace = true
 essential-node.workspace = true
 regex = "1.11.1"
+tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/essential-rest-client/src/lib.rs
+++ b/crates/essential-rest-client/src/lib.rs
@@ -1,12 +1,30 @@
+//! Client libraries for interacting with the Essential builder and the Essential node.
+
 #![deny(missing_docs)]
 
-//! Client libraries for interacting with the Essential builder and the Essential node.
+use anyhow::Context;
+use std::path::Path;
+
+use essential_types::{Contract, Program};
 
 /// Client library for sending requests to the Essential builder.
 pub mod builder_client;
-
 /// Client library for sending requests to the Essential node.
 pub mod node_client;
+
+/// A helper for reading a [`Contract`] and its [`Program`]s from a JSON file at the given path.
+///
+/// Specifically, expects the JSON to be the serialized form of `(Contract, Vec<Program>)`.
+pub async fn contract_from_path(contract_path: &Path) -> anyhow::Result<(Contract, Vec<Program>)> {
+    let contract_string = tokio::fs::read_to_string(&contract_path)
+        .await
+        .with_context(|| format!("failed to read contract from file {contract_path:?}"))?;
+    let (contract, programs): (Contract, Vec<Program>) = serde_json::from_str(&contract_string)
+        .with_context(|| {
+            format!("failed to parse contract and/or its programs from JSON at {contract_path:?}")
+        })?;
+    Ok((contract, programs))
+}
 
 /// Map `reqwest::Response` into `anyhow::Result`.
 async fn handle_response(response: reqwest::Response) -> anyhow::Result<reqwest::Response> {

--- a/crates/pint-deploy/Cargo.toml
+++ b/crates/pint-deploy/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 anyhow = { workspace = true }
 clap = { workspace = true }
 essential-hash = { workspace = true }
+essential-node-types = { workspace = true }
 essential-rest-client = { workspace = true }
 essential-types = { workspace = true }
 pint-cli = { workspace = true }


### PR DESCRIPTION
Based on #139 - ensures that programs used by contracts are also deployed alongside the contracts themselves in the `essential-rest-client` and related tools.