### PR TITLE
furnic/rename submit solution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,6 +956,7 @@ dependencies = [
  "base64",
  "clap",
  "essential-builder-types",
+ "essential-hash 0.9.0",
  "essential-node",
  "essential-node-api",
  "essential-node-types",

--- a/apps/counter/app/src/main.rs
+++ b/apps/counter/app/src/main.rs
@@ -67,7 +67,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             let solutions = SolutionSet {
                 solutions: vec![solution],
             };
-            let ca = builder.submit_solution(&solutions).await?;
+            let ca = builder.submit_solution_set(&solutions).await?;
             println!("Submitted solution: {}", ca);
             println!("Incremented count to: {}", new_count);
         }

--- a/apps/token/app/src/main.rs
+++ b/apps/token/app/src/main.rs
@@ -236,10 +236,10 @@ async fn mint(mut wallet: Wallet, args: Mint) -> anyhow::Result<ContentAddress> 
         token_symbol,
     };
     let solution = token::mint::build_solution(build_solution)?;
-    let solutions = SolutionSet {
+    let solution_set = SolutionSet {
         solutions: vec![solution],
     };
-    let ca = builder.submit_solution(&solutions).await?;
+    let ca = builder.submit_solution_set(&solution_set).await?;
     Ok(ca)
 }
 
@@ -282,10 +282,10 @@ async fn burn(mut wallet: Wallet, args: Burn) -> anyhow::Result<ContentAddress> 
         signature: sig,
     };
     let solution = token::burn::build_solution(build_solution)?;
-    let solutions = SolutionSet {
+    let solution_set = SolutionSet {
         solutions: vec![solution],
     };
-    let ca = builder.submit_solution(&solutions).await?;
+    let ca = builder.submit_solution_set(&solution_set).await?;
     Ok(ca)
 }
 
@@ -341,10 +341,10 @@ async fn transfer(mut wallet: Wallet, args: Transfer) -> anyhow::Result<ContentA
         signature: sig,
     };
     let solution = token::transfer::build_solution(build_solution)?;
-    let solutions = SolutionSet {
+    let solution_set = SolutionSet {
         solutions: vec![solution],
     };
-    let ca = builder.submit_solution(&solutions).await?;
+    let ca = builder.submit_solution_set(&solution_set).await?;
     Ok(ca)
 }
 

--- a/crates/essential-rest-client/Cargo.toml
+++ b/crates/essential-rest-client/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = { workspace = true }
 base64 = { workspace = true }
 clap = { workspace = true }
 essential-builder-types = { workspace = true }
+essential-hash = { workspace = true }
 essential-node-types = { workspace = true }
 essential-types = { workspace = true }
 hex.workspace = true

--- a/crates/essential-rest-client/src/main.rs
+++ b/crates/essential-rest-client/src/main.rs
@@ -47,11 +47,11 @@ enum Command {
         contract: PathBuf,
     },
     /// Submit a solution.
-    SubmitSolution {
+    SubmitSolutionSet {
         /// The endpoint of builder to bind to.
         builder_address: String,
-        /// Path to the solution file as a json `Solution`.
-        solution: PathBuf,
+        /// Path to the solution set file as a json `SolutionSet`.
+        solution_set: PathBuf,
     },
     /// Get the latest failures for solution.
     LatestSolutionFailures {
@@ -108,16 +108,14 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 .await?;
             println!("{}", output);
         }
-        Command::SubmitSolution {
+        Command::SubmitSolutionSet {
             builder_address,
-            solution,
+            solution_set,
         } => {
             let builder_client = EssentialBuilderClient::new(builder_address)?;
-            let solution = serde_json::from_str::<Solution>(&from_file(solution).await?)?;
-            let solutions = SolutionSet {
-                solutions: vec![solution],
-            };
-            let output = builder_client.submit_solution(&solutions).await?;
+            let solution_set =
+                serde_json::from_str::<SolutionSet>(&from_file(solution_set).await?)?;
+            let output = builder_client.submit_solution_set(&solution_set).await?;
             println!("{}", output);
         }
         Command::LatestSolutionFailures {

--- a/crates/pint-submit/src/main.rs
+++ b/crates/pint-submit/src/main.rs
@@ -33,7 +33,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
     let solution_set = serde_json::from_str::<SolutionSet>(&from_file(solutions).await?)?;
     let solution_ca = essential_hash::content_addr(&solution_set);
     print_submitting(&solution_ca);
-    let output = builder_client.submit_solution(&solution_set).await?;
+    let output = builder_client.submit_solution_set(&solution_set).await?;
     if solution_ca != output {
         anyhow::bail!("The content address of the submitted solution set differs from expected. May be a serialization error.");
     }


### PR DESCRIPTION
I'm picking apart some of the things that were formerly lumped into one PR (#137 ) which I intend to close; for now it is in Draft status for reference.

This is a simple renaming PR.

- refactor: rename submit_solution
- refactor: use new fn name for submit_solution
- refactor: use new name for submit_solution in apps
