### PR TITLE
Add function register_program

### DIFF
--- a/apps/counter/app/tests/builder_tests.rs
+++ b/apps/counter/app/tests/builder_tests.rs
@@ -145,7 +145,7 @@ async fn start_essential_builder() -> (Child, String, String) {
 async fn deploy_contract(builder_address: String) {
     let deploy_output = TokioCommand::new("essential-rest-client")
         .args([
-            "deploy-contract",
+            "register-contract",
             &format!("http://{}", builder_address.as_str()),
             concat!(env!("CARGO_MANIFEST_DIR"), "/../pint/out/debug/pint.json"),
         ])

--- a/crates/pint-deploy/src/main.rs
+++ b/crates/pint-deploy/src/main.rs
@@ -61,7 +61,12 @@ async fn run(args: Args) -> anyhow::Result<()> {
         );
         print_deploying(&name, &contract);
         let output = builder_client
-            .deploy_contract(&big_bang, &contract, &programs)
+            .register_contract(
+                big_bang.contract_registry,
+                big_bang.program_registry,
+                &contract,
+                &programs,
+            )
             .await?;
         print_received(&output);
         return Ok(());
@@ -95,7 +100,12 @@ async fn run(args: Args) -> anyhow::Result<()> {
             let (contract, programs) = contract_from_path(&contract_path).await?;
             print_deploying(&pinned.name, &contract);
             let output = builder_client
-                .deploy_contract(&big_bang, &contract, &programs)
+                .register_contract(
+                    big_bang.contract_registry,
+                    big_bang.program_registry,
+                    &contract,
+                    &programs,
+                )
                 .await?;
             print_received(&output);
         }


### PR DESCRIPTION
This PR:

- Adds a function to essential-rest-client to register programs
- Adds simple printing utils used by the `register-program` function


refs #146

<!-- ps-id: d0c84445-af53-4855-97d1-eff78545d92f -->
