### PR TITLE
refactor: rename deploy_contract

### DIFF
--- a/crates/essential-rest-client/src/builder_client.rs
+++ b/crates/essential-rest-client/src/builder_client.rs
@@ -25,7 +25,7 @@ impl EssentialBuilderClient {
     /// Deploy contract.
     ///
     /// Creates a solution to the contract registry predicate and submits it.
-    pub async fn deploy_contract(
+    pub async fn register_contract(
         &self,
         big_bang: &BigBang,
         contract: &Contract,

--- a/crates/essential-rest-client/src/main.rs
+++ b/crates/essential-rest-client/src/main.rs
@@ -40,7 +40,7 @@ enum Command {
         key: Key,
     },
     /// Deploy a contract.
-    DeployContract {
+    RegisterContract {
         /// The endpoint of builder to bind to.
         builder_address: String,
         /// Path to the contract file as a json `Contract`.
@@ -95,7 +95,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
                 .await?;
             println!("{}", serde_json::to_string(&output)?);
         }
-        Command::DeployContract {
+        Command::RegisterContract {
             builder_address,
             contract,
         } => {
@@ -104,7 +104,7 @@ async fn run(cli: Cli) -> anyhow::Result<()> {
             let builder_client = EssentialBuilderClient::new(builder_address)?;
             let (contract, programs) = contract_from_path(&contract).await?;
             let output = builder_client
-                .deploy_contract(&big_bang, &contract, &programs)
+                .register_contract(&big_bang, &contract, &programs)
                 .await?;
             println!("{}", output);
         }

--- a/crates/pint-deploy/src/main.rs
+++ b/crates/pint-deploy/src/main.rs
@@ -61,7 +61,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
         );
         print_deploying(&name, &contract);
         let output = builder_client
-            .deploy_contract(&big_bang, &contract, &programs)
+            .register_contract(&big_bang, &contract, &programs)
             .await?;
         print_received(&output);
         return Ok(());
@@ -95,7 +95,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
             let (contract, programs) = contract_from_path(&contract_path).await?;
             print_deploying(&pinned.name, &contract);
             let output = builder_client
-                .deploy_contract(&big_bang, &contract, &programs)
+                .register_contract(&big_bang, &contract, &programs)
                 .await?;
             print_received(&output);
         }


### PR DESCRIPTION
All in the title.
A simple rename of a function, and updating refs to this fn.

Note: This depends on #149 

refs: #146

<!-- ps-id: 3c65f822-83c4-4d41-b3ba-aa69feadbf5f -->
