### PR TITLE
Register programs in both cases

### DIFF
--- a/crates/pint-deploy/src/main.rs
+++ b/crates/pint-deploy/src/main.rs
@@ -119,6 +119,17 @@ async fn run(args: Args) -> anyhow::Result<()> {
                     &programs,
                 )
                 .await?;
+
+            join_all(programs.iter().map(|p| {
+                let builder_client = &builder_client;
+                async {
+                    builder_client
+                        .register_program(&big_bang.program_registry, p)
+                        .await
+                }
+            }))
+            .await;
+
             print_received(&output);
         }
     }


### PR DESCRIPTION
FIx: #151 failed to perform the program registration in the case where the contract was Not specified directly.
This fixes that.

Note: I opened #152 to track needed chenges.

<!-- ps-id: ba1077ec-9c48-4b92-8827-5c83bfa357be -->